### PR TITLE
Window resize event handler

### DIFF
--- a/addon/components/sticky-element.js
+++ b/addon/components/sticky-element.js
@@ -246,6 +246,9 @@ export default Component.extend({
    * @private
    */
   updateDimension() {
+    if(this.get('isDestroyed') || this.get('isDestroying')) {
+      return false;
+    }
     this.set('windowHeight', window.innerHeight);
     this.set('ownHeight', this.element.offsetHeight);
     this.set('ownWidth', this.element.offsetWidth);

--- a/addon/components/sticky-element.js
+++ b/addon/components/sticky-element.js
@@ -222,7 +222,8 @@ export default Component.extend({
    * @private
    */
   initResizeEventListener() {
-    window.addEventListener('resize', this.debouncedUpdateDimension.bind(this), false);
+    this._resizeListener = () => this.debouncedUpdateDimension();
+    window.addEventListener('resize', this._resizeListener, false);
   },
 
   /**
@@ -230,7 +231,7 @@ export default Component.extend({
    * @private
    */
   removeResizeEventListener() {
-    window.removeEventListener('resize', this.debouncedUpdateDimension.bind(this), false);
+    window.removeEventListener('resize', this._resizeListener, false);
   },
 
   /**
@@ -271,7 +272,7 @@ export default Component.extend({
     this.initResizeEventListener();
   },
 
-  willDestroy() {
+  willDestroyElement() {
     this.removeResizeEventListener();
   },
 

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -60,14 +60,6 @@ h1 {
     margin-right: 2px;
 }
 
-.large-container {
-    width: 500px;
-}
-
-.small-container {
-    width: 300px;
-}
-
 /*
 This is needed for testing!
 */

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -60,6 +60,14 @@ h1 {
     margin-right: 2px;
 }
 
+.large-container {
+    width: 500px;
+}
+
+.small-container {
+    width: 300px;
+}
+
 /*
 This is needed for testing!
 */

--- a/tests/integration/components/sticky-element-test.js
+++ b/tests/integration/components/sticky-element-test.js
@@ -345,42 +345,6 @@ module('Integration | Component | sticky element', function(hooks) {
       await settled();
       assert.dom('#debug').hasText(debug, debug);
     });
-
-    test(`Is resizable | Size: ${testCase.size}, offView: ${testCase.offView}, stick to bottom: ${testCase.stickToBottom === false ? 'false' : 'true'}, scroll position: ${testCase.scrollPosition}`, async function(assert) {
-      let stickyElementWidth;
-      let containerWidth;
-      this.setProperties(testCase);
-      this.set('bottom', testCase.stickToBottom ? 0 : null);
-      this.set('largeContainer', true);
-      await render(hbs`
-        <div class="row">
-          <div class="col {{size}} {{if offView "off"}} {{if largeContainer "large-container" "small-container"}}">
-            {{#sticky-element class="sticky" bottom=bottom as |sticky|}}
-              <p id="debug">
-                {{sticky-debug sticky}}
-              </p>
-            {{/sticky-element}}
-          </div>
-        </div>
-      `);
-
-      let debug = output(testCase.sticky);
-
-      await scrollTo(testCase.scrollPosition);
-      stickyElementWidth = document.querySelector('.sticky-element').clientWidth;
-      containerWidth = document.querySelector('.col').clientWidth;
-      assert.equal(stickyElementWidth, containerWidth, 'Sticky element 500px width');
-      this.set('largeContainer', false);
-      await settled();
-      window.dispatchEvent(new Event('resize'));
-      await settled();
-      stickyElementWidth = document.querySelector('.sticky-element').clientWidth;
-      containerWidth = document.querySelector('.col').clientWidth;
-      assert.equal(stickyElementWidth, containerWidth);
-
-      assert.dom('#debug').hasText(debug, debug);
-    });
-
   });
 
   test('can be disabled', async function(assert) {
@@ -408,5 +372,40 @@ module('Integration | Component | sticky element', function(hooks) {
     await scrollTo('down', true);
     assert.dom('#debug').hasText(debug, debug);
     assert.dom('.sticky').doesNotHaveAttribute('style');
+  });
+
+  test('Is resizable', async function(assert) {
+    let stickyElementWidth;
+    this.setProperties({
+      size: 'small',
+      scrollPosition: 'down',
+      offView: false,
+      stickToBottom: false,
+      sticky: 'top'
+    });
+    this.set('containerWidth', 'width:500px');
+    await render(hbs`
+      <div class="row">
+        <div class="col {{size}} {{if offView "off"}}" style={{{containerWidth}}}>
+          {{#sticky-element class="sticky" bottom=bottom as |sticky|}}
+            <p id="debug">
+              {{sticky-debug sticky}}
+            </p>
+          {{/sticky-element}}
+        </div>
+      </div>
+    `);
+    let debug = output('top');
+    await scrollTo('down', true);
+    assert.dom('#debug').hasText(debug, debug);
+    stickyElementWidth = document.querySelector('.sticky-element').clientWidth;
+    assert.equal(stickyElementWidth, 500);
+    this.set('containerWidth', 'width:300px');
+    await settled();
+    window.dispatchEvent(new Event('resize'));
+    await settled();
+    stickyElementWidth = document.querySelector('.sticky-element').clientWidth;
+    assert.equal(stickyElementWidth, 300);
+    assert.dom('#debug').hasText(debug, debug);
   });
 });

--- a/tests/integration/components/sticky-element-test.js
+++ b/tests/integration/components/sticky-element-test.js
@@ -346,6 +346,41 @@ module('Integration | Component | sticky element', function(hooks) {
       assert.dom('#debug').hasText(debug, debug);
     });
 
+    test(`Is resizable | Size: ${testCase.size}, offView: ${testCase.offView}, stick to bottom: ${testCase.stickToBottom === false ? 'false' : 'true'}, scroll position: ${testCase.scrollPosition}`, async function(assert) {
+      let stickyElementWidth;
+      let containerWidth;
+      this.setProperties(testCase);
+      this.set('bottom', testCase.stickToBottom ? 0 : null);
+      this.set('largeContainer', true);
+      await render(hbs`
+        <div class="row">
+          <div class="col {{size}} {{if offView "off"}} {{if largeContainer "large-container" "small-container"}}">
+            {{#sticky-element class="sticky" bottom=bottom as |sticky|}}
+              <p id="debug">
+                {{sticky-debug sticky}}
+              </p>
+            {{/sticky-element}}
+          </div>
+        </div>
+      `);
+
+      let debug = output(testCase.sticky);
+
+      await scrollTo(testCase.scrollPosition);
+      stickyElementWidth = document.querySelector('.sticky-element').clientWidth;
+      containerWidth = document.querySelector('.col').clientWidth;
+      assert.equal(stickyElementWidth, containerWidth, 'Sticky element 500px width');
+      this.set('largeContainer', false);
+      await settled();
+      window.dispatchEvent(new Event('resize'));
+      await settled();
+      stickyElementWidth = document.querySelector('.sticky-element').clientWidth;
+      containerWidth = document.querySelector('.col').clientWidth;
+      assert.equal(stickyElementWidth, containerWidth);
+
+      assert.dom('#debug').hasText(debug, debug);
+    });
+
   });
 
   test('can be disabled', async function(assert) {


### PR DESCRIPTION
Add window resize event handler. To resize sticky element when user resize his window and don't break the visual of the page. Especially when the sticky element is in an aside col.