### PR TITLE
Use setProperties instead of multiple set

### DIFF
--- a/addon/components/sticky-element.js
+++ b/addon/components/sticky-element.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { or, notEmpty } from '@ember/object/computed';
 import { htmlSafe } from '@ember/string';
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { computed, setProperties } from '@ember/object';
 import { later, cancel, debounce } from '@ember/runloop';
 import layout from '../templates/components/sticky-element';
 
@@ -268,9 +268,11 @@ export default Component.extend({
     if(this.get('isDestroyed') || this.get('isDestroying')) {
       return false;
     }
-    this.set('windowHeight', window.innerHeight);
-    this.set('ownHeight', this.element.offsetHeight);
-    this.set('ownWidth', this.element.offsetWidth);
+    setProperties(this, {
+      windowHeight: window.innerHeight,
+      ownHeight: this.element.offsetHeight,
+      ownWidth: this.element.offsetWidth
+    });
   },
 
   updatePosition() {


### PR DESCRIPTION
This should improve performance on computed properties.
From the [ember docs](https://www.emberjs.com/api/ember/release/functions/@ember%2Fobject/setProperties)

```
Set a list of properties on an object.
These properties are set inside a single beginPropertyChanges and endPropertyChanges batch,
so observers will be buffered.
```